### PR TITLE
fix: ensure fix_json output always parses as JSON

### DIFF
--- a/crates/partial-json-fixer/Cargo.lock
+++ b/crates/partial-json-fixer/Cargo.lock
@@ -3,5 +3,103 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
 name = "partial-json-fixer"
 version = "0.5.3"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/partial-json-fixer/Cargo.toml
+++ b/crates/partial-json-fixer/Cargo.toml
@@ -11,3 +11,6 @@ keywords = ["json", "partial-json"]
 categories = ["text-processing", "parsing"]
 
 [dependencies]
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/partial-json-fixer/src/lib.rs
+++ b/crates/partial-json-fixer/src/lib.rs
@@ -28,23 +28,39 @@ pub fn fix_json(partial_json: &str) -> String {
         Brace,
         SquareBracket,
         Quote,
-        Escape,
         ObjectKey,
         ObjectValue,
     }
-    let chars = partial_json.chars();
     let mut wrappers = vec![];
-    for c in chars {
+    // Byte index of an unescaped backslash waiting for its escape character.
+    let mut pending_escape: Option<usize> = None;
+    // (byte index of the backslash, hex digits seen so far) while inside a
+    // possibly-incomplete `\uXXXX` sequence.
+    let mut unicode_escape: Option<(usize, usize)> = None;
+    for (idx, c) in partial_json.char_indices() {
         match wrappers.last() {
             Some(Wrapper::Quote) => {
-                if c == '"' {
+                if let Some(esc_idx) = pending_escape.take() {
+                    // This char completes a `\c` escape sequence.
+                    if c == 'u' || c == 'U' {
+                        unicode_escape = Some((esc_idx, 0));
+                    }
+                } else if let Some((_, hex_count)) = unicode_escape.as_mut() {
+                    if *hex_count < 4 && c.is_ascii_hexdigit() {
+                        *hex_count += 1;
+                    } else {
+                        unicode_escape = None;
+                        if c == '"' {
+                            wrappers.pop();
+                        } else if c == '\\' {
+                            pending_escape = Some(idx);
+                        }
+                    }
+                } else if c == '"' {
                     wrappers.pop();
                 } else if c == '\\' {
-                    wrappers.push(Wrapper::Escape);
+                    pending_escape = Some(idx);
                 }
-            }
-            Some(Wrapper::Escape) => {
-                wrappers.pop(); // get out of escape mode 
             }
             _ => {
                 match c {
@@ -99,16 +115,75 @@ pub fn fix_json(partial_json: &str) -> String {
     // If the input ends inside an unterminated string, the final comma is
     // string content and must be preserved. Quote and Escape can only ever
     // appear at the top of the stack.
-    let ends_inside_string = matches!(
-        wrappers.last(),
-        Some(Wrapper::Quote | Wrapper::Escape)
-    );
+    let ends_inside_string = matches!(wrappers.last(), Some(Wrapper::Quote));
 
-    let end_index = if !ends_inside_string && partial_json.trim_end().ends_with(',') {
+    let mut end_index = if !ends_inside_string && partial_json.trim_end().ends_with(',') {
         partial_json.rfind(',').unwrap()
     } else {
         partial_json.len()
     };
+
+    // Repair an incomplete trailing token so the output always parses as JSON.
+    // https://github.com/maheshbansod/partial-json-fixer/issues/4
+    match wrappers.last() {
+        Some(Wrapper::Quote) => {
+            // Ends inside an unterminated string: drop a dangling partial
+            // escape sequence (a lone `\` or an incomplete `\uXXXX`).
+            if let Some(esc_idx) = pending_escape {
+                end_index = end_index.min(esc_idx);
+            } else if let Some((bs_idx, hex_count)) = unicode_escape {
+                if hex_count < 4 {
+                    end_index = end_index.min(bs_idx);
+                }
+            }
+        }
+        _ => {
+            // Ends in (or right after) a bareword token: trim a truncated
+            // literal or number back to something a JSON parser accepts.
+            let trimmed = partial_json[..end_index].trim_end();
+            let tok_start = trimmed
+                .char_indices()
+                .rev()
+                .take_while(|(_i, c)| c.is_alphanumeric() || matches!(c, '.' | '+' | '-'))
+                .last()
+                .map(|(i, _)| i);
+            if let Some(start) = tok_start {
+                let tok = &trimmed[start..];
+                let is_numberish = tok.chars().all(|c| {
+                    c.is_ascii_digit() || matches!(c, '.' | '+' | '-' | 'e' | 'E')
+                });
+                let truncated_literal = ["true", "false", "null"]
+                    .iter()
+                    .any(|l| l.starts_with(tok) && *l != tok);
+                if truncated_literal || (is_numberish && !is_valid_json_number(tok)) {
+                    if !truncated_literal && is_numberish {
+                        // Numbers: trim back to the longest valid prefix
+                        // (e.g. `12.` -> `12`, `1e-` -> `1`).
+                        let mut best = None;
+                        for (off, _) in tok.char_indices().skip(1) {
+                            if is_valid_json_number(&tok[..off]) {
+                                best = Some(off);
+                            }
+                        }
+                        end_index = start + best.unwrap_or(0);
+                    } else {
+                        end_index = start;
+                    }
+                    match partial_json[..end_index].trim_end().chars().next_back() {
+                        Some(':') => {
+                            // The value slot is now empty; make the closing pass fill it.
+                            wrappers.push(Wrapper::ObjectValue);
+                        }
+                        Some(',') => {
+                            // A dangling separator would be invalid; drop it.
+                            end_index = partial_json[..end_index].trim_end().len() - 1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
 
     let mut final_json = partial_json[0..end_index].to_string();
     while let Some(wrapper) = wrappers.pop() {
@@ -131,19 +206,69 @@ pub fn fix_json(partial_json: &str) -> String {
                     wrappers.pop();
                 }
             },
-            Wrapper::Escape => {
-                final_json.push('\\');
-            },
             Wrapper::ObjectKey => {
                 final_json.push_str(": null");
             },
             Wrapper::ObjectValue => {
-                final_json.push_str(" null");
+                if !final_json.ends_with(char::is_whitespace) {
+                    final_json.push(' ');
+                }
+                final_json.push_str("null");
             },
         }
     }
 
+    if final_json.is_empty() {
+        // An empty input is still a prefix of valid JSON; emit something parseable.
+        return "null".to_string();
+    }
+
     final_json
+}
+
+/// Checks whether `s` is a complete JSON number (stricter than `f64::from_str`,
+/// which accepts things like "12." that serde_json rejects).
+fn is_valid_json_number(s: &str) -> bool {
+    let mut chars = s.chars().peekable();
+    if chars.peek() == Some(&'-') {
+        chars.next();
+    }
+    // integer part
+    match chars.peek() {
+        Some('0') => {
+            chars.next();
+        }
+        Some(c) if c.is_ascii_digit() => {
+            while matches!(chars.peek(), Some(c) if c.is_ascii_digit()) {
+                chars.next();
+            }
+        }
+        _ => return false,
+    }
+    // fraction
+    if chars.peek() == Some(&'.') {
+        chars.next();
+        if !matches!(chars.peek(), Some(c) if c.is_ascii_digit()) {
+            return false;
+        }
+        while matches!(chars.peek(), Some(c) if c.is_ascii_digit()) {
+            chars.next();
+        }
+    }
+    // exponent
+    if matches!(chars.peek(), Some('e') | Some('E')) {
+        chars.next();
+        if matches!(chars.peek(), Some('+') | Some('-')) {
+            chars.next();
+        }
+        if !matches!(chars.peek(), Some(c) if c.is_ascii_digit()) {
+            return false;
+        }
+        while matches!(chars.peek(), Some(c) if c.is_ascii_digit()) {
+            chars.next();
+        }
+    }
+    chars.next().is_none()
 }
 
 struct JsonParser<'a> {

--- a/crates/partial-json-fixer/src/lib.rs
+++ b/crates/partial-json-fixer/src/lib.rs
@@ -24,13 +24,6 @@ pub fn fix_json_parse(partial_json: &str) -> JResult<JsonValue<'_>> {
 /// This approach is likely faster than the parsing appraoch (TODO: benchmmark maybe)
 /// It's assumed that the given JSON would **always** be a valid incomplete JSON.
 pub fn fix_json(partial_json: &str) -> String {
-    enum Wrapper {
-        Brace,
-        SquareBracket,
-        Quote,
-        ObjectKey,
-        ObjectValue,
-    }
     let mut wrappers = vec![];
     // Byte index of an unescaped backslash waiting for its escape character.
     let mut pending_escape: Option<usize> = None;
@@ -42,7 +35,7 @@ pub fn fix_json(partial_json: &str) -> String {
             Some(Wrapper::Quote) => {
                 if let Some(esc_idx) = pending_escape.take() {
                     // This char completes a `\c` escape sequence.
-                    if c == 'u' || c == 'U' {
+                    if c == 'u' {
                         unicode_escape = Some((esc_idx, 0));
                     }
                 } else if let Some((_, hex_count)) = unicode_escape.as_mut() {
@@ -125,65 +118,13 @@ pub fn fix_json(partial_json: &str) -> String {
 
     // Repair an incomplete trailing token so the output always parses as JSON.
     // https://github.com/maheshbansod/partial-json-fixer/issues/4
-    match wrappers.last() {
-        Some(Wrapper::Quote) => {
-            // Ends inside an unterminated string: drop a dangling partial
-            // escape sequence (a lone `\` or an incomplete `\uXXXX`).
-            if let Some(esc_idx) = pending_escape {
-                end_index = end_index.min(esc_idx);
-            } else if let Some((bs_idx, hex_count)) = unicode_escape {
-                if hex_count < 4 {
-                    end_index = end_index.min(bs_idx);
-                }
-            }
-        }
-        _ => {
-            // Ends in (or right after) a bareword token: trim a truncated
-            // literal or number back to something a JSON parser accepts.
-            let trimmed = partial_json[..end_index].trim_end();
-            let tok_start = trimmed
-                .char_indices()
-                .rev()
-                .take_while(|(_i, c)| c.is_alphanumeric() || matches!(c, '.' | '+' | '-'))
-                .last()
-                .map(|(i, _)| i);
-            if let Some(start) = tok_start {
-                let tok = &trimmed[start..];
-                let is_numberish = tok.chars().all(|c| {
-                    c.is_ascii_digit() || matches!(c, '.' | '+' | '-' | 'e' | 'E')
-                });
-                let truncated_literal = ["true", "false", "null"]
-                    .iter()
-                    .any(|l| l.starts_with(tok) && *l != tok);
-                if truncated_literal || (is_numberish && !is_valid_json_number(tok)) {
-                    if !truncated_literal && is_numberish {
-                        // Numbers: trim back to the longest valid prefix
-                        // (e.g. `12.` -> `12`, `1e-` -> `1`).
-                        let mut best = None;
-                        for (off, _) in tok.char_indices().skip(1) {
-                            if is_valid_json_number(&tok[..off]) {
-                                best = Some(off);
-                            }
-                        }
-                        end_index = start + best.unwrap_or(0);
-                    } else {
-                        end_index = start;
-                    }
-                    match partial_json[..end_index].trim_end().chars().next_back() {
-                        Some(':') => {
-                            // The value slot is now empty; make the closing pass fill it.
-                            wrappers.push(Wrapper::ObjectValue);
-                        }
-                        Some(',') => {
-                            // A dangling separator would be invalid; drop it.
-                            end_index = partial_json[..end_index].trim_end().len() - 1;
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-    }
+    end_index = repair_incomplete_trailing_token(
+        partial_json,
+        end_index,
+        ends_inside_string,
+        (pending_escape, unicode_escape),
+        &mut wrappers,
+    );
 
     let mut final_json = partial_json[0..end_index].to_string();
     while let Some(wrapper) = wrappers.pop() {
@@ -218,12 +159,103 @@ pub fn fix_json(partial_json: &str) -> String {
         }
     }
 
-    if final_json.is_empty() {
-        // An empty input is still a prefix of valid JSON; emit something parseable.
+    if final_json.trim().is_empty() {
+        // An empty (or whitespace-only) input is still a prefix of valid
+        // JSON; emit something parseable.
         return "null".to_string();
     }
 
     final_json
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum Wrapper {
+    Brace,
+    SquareBracket,
+    Quote,
+    ObjectKey,
+    ObjectValue,
+}
+
+/// Byte index of an unescaped backslash waiting for its escape character, and
+/// how many hex digits have been seen while inside a possibly-incomplete
+/// `\uXXXX` sequence.
+type EscapeState = (Option<usize>, Option<(usize, usize)>);
+
+/// Adjusts `end_index` so any incomplete trailing token is repaired and the
+/// output always parses as JSON:
+/// - inside an unterminated string: drop a dangling lone `\` or partial `\uXXXX`
+/// - otherwise: trim a truncated literal (`tru`) or number (`12.`, `1e-`)
+///
+/// May push an `ObjectValue` wrapper so the closing pass fills an emptied
+/// value slot with `null`.
+fn repair_incomplete_trailing_token(
+    partial_json: &str,
+    mut end_index: usize,
+    ends_inside_string: bool,
+    escape_state: EscapeState,
+    wrappers: &mut Vec<Wrapper>,
+) -> usize {
+    let (pending_escape, unicode_escape) = escape_state;
+    if ends_inside_string {
+        if let Some(esc_idx) = pending_escape {
+            end_index = end_index.min(esc_idx);
+        } else if let Some((bs_idx, hex_count)) = unicode_escape {
+            if hex_count < 4 {
+                end_index = end_index.min(bs_idx);
+            }
+        }
+        return end_index;
+    }
+
+    // Ends in (or right after) a bareword token: trim a truncated literal or
+    // number back to something a JSON parser accepts.
+    let trimmed = partial_json[..end_index].trim_end();
+    let tok_start = trimmed
+        .char_indices()
+        .rev()
+        .take_while(|(_i, c)| c.is_alphanumeric() || matches!(c, '.' | '+' | '-'))
+        .last()
+        .map(|(i, _)| i);
+    let Some(start) = tok_start else {
+        return end_index;
+    };
+    let tok = &trimmed[start..];
+    let is_numberish =
+        tok.chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '.' | '+' | '-' | 'e' | 'E'));
+    let truncated_literal = ["true", "false", "null"]
+        .iter()
+        .any(|l| l.starts_with(tok) && *l != tok);
+    if !(truncated_literal || (is_numberish && !is_valid_json_number(tok))) {
+        return end_index;
+    }
+
+    if truncated_literal {
+        end_index = start;
+    } else {
+        // Numbers: trim back to the longest valid prefix
+        // (e.g. `12.` -> `12`, `1e-` -> `1`).
+        let mut best = None;
+        for (off, _) in tok.char_indices().skip(1) {
+            if is_valid_json_number(&tok[..off]) {
+                best = Some(off);
+            }
+        }
+        end_index = start + best.unwrap_or(0);
+    }
+    match partial_json[..end_index].trim_end().chars().next_back() {
+        Some(':') => {
+            // The value slot is now empty; make the closing pass fill it.
+            wrappers.push(Wrapper::ObjectValue);
+        }
+        Some(',') => {
+            // A dangling separator would be invalid; drop it.
+            end_index = partial_json[..end_index].trim_end().len() - 1;
+        }
+        _ => {}
+    }
+    end_index
 }
 
 /// Checks whether `s` is a complete JSON number (stricter than `f64::from_str`,

--- a/crates/partial-json-fixer/tests/tests.rs
+++ b/crates/partial-json-fixer/tests/tests.rs
@@ -318,6 +318,21 @@ mod always_parseable {
     }
 
     #[test]
+    fn empty_and_whitespace_only_input() {
+        assert_eq!(fix_json_to_string("").unwrap(), "null");
+        assert_eq!(fix_json_to_string("   ").unwrap(), "null");
+        assert_parses("");
+        assert_parses("   ");
+    }
+
+    #[test]
+    fn uppercase_u_escape_is_not_unicode_escape() {
+        // JSON only defines lowercase `\u`; `\U` is a plain escaped char.
+        let result = fix_json_to_string(r#"{"s": "ab\U00"#).unwrap();
+        assert_eq!(result, r#"{"s": "ab\U00"}"#);
+    }
+
+    #[test]
     fn every_cut_point_of_sample_documents_parses() {
         let docs = [
             r#"{"s": "ab\u00c3 def \\ end", "t": "x\ny"}"#,

--- a/crates/partial-json-fixer/tests/tests.rs
+++ b/crates/partial-json-fixer/tests/tests.rs
@@ -241,3 +241,98 @@ fn test_structural_trailing_comma_after_string_still_stripped() {
     let result = fix_json_to_string(partial).unwrap();
     assert_eq!(result, "{\"a\": \"x\"}");
 }
+
+// https://github.com/maheshbansod/partial-json-fixer/issues/4
+mod always_parseable {
+    use super::*;
+
+    fn assert_parses(partial: &str) {
+        let fixed = fix_json_to_string(partial).unwrap();
+        serde_json::from_str::<serde_json::Value>(&fixed)
+            .unwrap_or_else(|e| panic!("fix_json({partial:?}) = {fixed:?} does not parse: {e}"));
+    }
+
+    #[test]
+    fn cut_inside_unicode_escape() {
+        let result = fix_json_to_string(r#"{"s": "ab\u00"#).unwrap();
+        assert_eq!(result, r#"{"s": "ab"}"#);
+        assert_parses(r#"{"s": "ab\u00"#);
+    }
+
+    #[test]
+    fn cut_at_lone_backslash() {
+        let result = fix_json_to_string(r#"{"s": "ab\"#).unwrap();
+        assert_eq!(result, r#"{"s": "ab"}"#);
+        assert_parses(r#"{"s": "ab\"#);
+    }
+
+    #[test]
+    fn complete_escape_at_end_untouched() {
+        let result = fix_json_to_string(r#"{"s": "ab\n"#).unwrap();
+        assert_eq!(result, r#"{"s": "ab\n"}"#);
+        assert_parses(r#"{"s": "ab\n"#);
+    }
+
+    #[test]
+    fn cut_after_decimal_point() {
+        let result = fix_json_to_string("{\"n\": 12.").unwrap();
+        assert_eq!(result, "{\"n\": 12}");
+        assert_parses("{\"n\": 12.");
+    }
+
+    #[test]
+    fn cut_inside_exponent() {
+        // Trimmed back to the longest valid number prefix.
+        let result = fix_json_to_string("{\"n\": 1e").unwrap();
+        assert_eq!(result, "{\"n\": 1}");
+        assert_parses("{\"n\": 1e");
+    }
+
+    #[test]
+    fn cut_inside_exponent_sign() {
+        assert_parses("{\"n\": 1e-");
+    }
+
+    #[test]
+    fn cut_at_minus_sign() {
+        assert_parses("{\"n\": -");
+    }
+
+    #[test]
+    fn truncated_literal_true() {
+        let result = fix_json_to_string("{\"b\": tru").unwrap();
+        assert_eq!(result, "{\"b\": null}");
+        assert_parses("{\"b\": tru");
+    }
+
+    #[test]
+    fn truncated_literal_false_and_null() {
+        assert_parses("{\"b\": fals");
+        assert_parses("{\"x\": nul");
+        assert_parses("[tru");
+    }
+
+    #[test]
+    fn complete_json_untouched() {
+        assert_eq!(fix_json_to_string("[true, false, null, 1.5, 1e10]").unwrap(), "[true, false, null, 1.5, 1e10]");
+    }
+
+    #[test]
+    fn every_cut_point_of_sample_documents_parses() {
+        let docs = [
+            r#"{"s": "ab\u00c3 def \\ end", "t": "x\ny"}"#,
+            r#"{"n": 12.5, "m": -1e10, "k": 0.5e-3}"#,
+            r#"{"b": true, "c": false, "d": null, "arr": [true, false]}"#,
+            r#"[1.5e3, {"key": "val\u0041ue"}, [null, true]]"#,
+            r#"{"nested": {"deep": [{"s": "esc \u001f tap \t", "n": 3.14}]}}"#,
+        ];
+        for doc in docs {
+            for (i, _) in doc.char_indices() {
+                let partial = &doc[..i];
+                assert_parses(partial);
+            }
+            assert_parses(doc);
+        }
+    }
+}
+


### PR DESCRIPTION
Closes #4

## Problem

When streaming input is cut inside an incomplete token, \`fix_json\` closed brackets and quotes around whatever text was present, producing output no JSON parser accepts:

| Input (cut mid-token) | Old output | Problem |
|---|---|---|
| \`{"s": "ab\\u00\` | \`{"s": "ab\\u00"}\` | dangling partial \`\u\` escape |
| \`{"s": "ab\\\` | \`{"s": "ab\\"}\` | lone backslash escapes the closing quote |
| \`{"n": 12.\` / \`{"n": 1e\` | unchanged + \`}\` | invalid number |
| \`{"b": tru\` | \`{"b": tru}\` | truncated literal |

## Fix

Track string-escape state (\`pending_escape\`, \`unicode_escape\`) during the existing scan, then a new \`repair_incomplete_trailing_token\` pass adjusts the cut point:

- **Incomplete escape in string content**: dropped entirely (\`"ab\u00\` → \`"ab"\`, lone trailing backslash likewise)
- **Invalid trailing number**: trimmed to its longest valid JSON-number prefix (\`12.\` → \`12\`, \`1e-\` → \`1\`; strict validator since Rust's \`f64::from_str\` wrongly accepts \`12.\`)
- **Truncated literal** (\`tru\`, \`fals\`, \`nul\`): trimmed; if that leaves an empty value slot after \`:", the closer fills it with \`null\`, and dangling separators are dropped
- **Empty/whitespace-only input** now returns \`null\` instead of \`""\`

Out of contract inputs (e.g. \`{key: mu\` — not a prefix of valid JSON) are left untouched, preserving old behavior.

## Testing

- Unit tests for each issue example plus edge cases (complete escapes untouched, \`\U\` is not a unicode escape per JSON spec)
- Property-style test cutting 5 sample documents (escapes, numbers, literals) at every character offset — every output verified with serde_json
- All 44 tests pass; clippy clean on both crates

## Notes for review

- \`serde_json\` added as a **dev-dependency only** — runtime stays zero-dependency
- The wrapper \`enum\` moved to module scope so the repair pass can be a standalone function