### PR TITLE
fix: preserve all valid JSON numbers in fix_json_parse

### DIFF
--- a/crates/partial-json-fixer/src/lib.rs
+++ b/crates/partial-json-fixer/src/lib.rs
@@ -349,7 +349,9 @@ impl<'a> JsonParser<'a> {
         if source == "false" {
             return JsonUnit::False;
         }
-        if source.parse::<isize>().is_ok() {
+        // JsonUnit::Number keeps the raw slice, so anything matching the JSON
+        // number grammar round-trips textually — no numeric conversion needed.
+        if is_valid_json_number(source) {
             return JsonUnit::Number(source);
         }
         JsonUnit::Null
@@ -588,7 +590,7 @@ impl<'a> JsonTokenizer<'a> {
         loop {
             if let Some((i, c)) = it_clone.next() {
                 last_index = i;
-                if !c.is_alphanumeric() {
+                if !c.is_alphanumeric() && !matches!(c, '.' | '+' | '-') {
                     break;
                 }
                 self.char_indices.next();

--- a/crates/partial-json-fixer/tests/tests.rs
+++ b/crates/partial-json-fixer/tests/tests.rs
@@ -351,3 +351,83 @@ mod always_parseable {
     }
 }
 
+mod parse_numbers {
+    // https://github.com/maheshbansod/partial-json-fixer/issues/3
+    use partial_json_fixer::{fix_json_parse, JsonUnit};
+
+    fn unit_text(input: &str) -> String {
+        match fix_json_parse(input).unwrap() {
+            partial_json_fixer::JsonValue::Unit(unit) => unit.to_string(),
+            other => panic!("expected a unit for {input:?}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn top_level_float_round_trips() {
+        assert_eq!(unit_text("3.14"), "3.14");
+    }
+
+    #[test]
+    fn float_inside_object_parses() {
+        let value = fix_json_parse(r#"{"pi": 3.14159}"#).unwrap();
+        assert_eq!(
+            match value {
+                partial_json_fixer::JsonValue::Object(obj) => obj.values[0].1.to_string(),
+                other => panic!("expected an object, got {other:?}"),
+            },
+            "3.14159"
+        );
+    }
+
+    #[test]
+    fn exponent_forms_round_trip() {
+        for input in ["1.5e10", "2E-3", "1e+10", "5e10"] {
+            assert_eq!(unit_text(input), input);
+        }
+    }
+
+    #[test]
+    fn negative_decimals_round_trip() {
+        for input in ["-2.5", "-0.5e-3"] {
+            assert_eq!(unit_text(input), input);
+        }
+    }
+
+    #[test]
+    fn integers_beyond_isize_round_trip() {
+        assert_eq!(unit_text("92233720368547758080"), "92233720368547758080");
+    }
+
+    #[test]
+    fn numbers_are_number_units() {
+        for input in ["3.14", "-2.5", "1e+10", "92233720368547758080"] {
+            assert!(matches!(
+                fix_json_parse(input).unwrap(),
+                partial_json_fixer::JsonValue::Unit(JsonUnit::Number(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn container_display_re_emits_numbers_byte_identical() {
+        let inputs = [
+            r#"{"pi": 3.14159}"#,
+            r#"{"e": 1.5e10, "neg": -2.5}"#,
+            r#"[3.14, -0.5e-3, 92233720368547758080]"#,
+            r#"{"big": 92233720368547758080}"#,
+        ];
+        for input in inputs {
+            let value = fix_json_parse(input).unwrap();
+            assert_eq!(value.to_string(), input);
+        }
+    }
+
+    #[test]
+    fn non_number_barewords_still_become_null() {
+        assert!(matches!(
+            fix_json_parse("tru").unwrap(),
+            partial_json_fixer::JsonValue::Unit(JsonUnit::Null)
+        ));
+    }
+}
+


### PR DESCRIPTION
Fixes #3

## Problem
\`fix_json_parse\` mangled every non-integer JSON number:
- Number tokens stopped at any non-alphanumeric char, splitting floats/exponents/negatives at \`. \` \`-\` \`+\` → top-level numbers truncated (\`3.14\` → \`Number("3")\`), valid JSON inside containers returned \`Err(ExpectedToken)\`
- \`token_as_unit\` only accepted \`isize\`-parseable integers, silently mapping everything else (including ints past \`isize::MAX\`) to \`null\`

## Fix
Two small changes in \`crates/partial-json-fixer/src/lib.rs\`:
1. \`consume_number_or_null\` now also continues through \`. \` \`+\` \`-\`, so a token spans the full JSON number grammar
2. \`token_as_unit\` validates via the existing \`is_valid_json_number\` helper instead of \`parse::<isize>\`; since \`JsonUnit::Number\` stores a raw string slice, all numbers round-trip textually with no numeric conversion

No public API changes.

## Tests
New \`parse_numbers\` module covering every acceptance criterion from the issue: top-level float, float in object, exponent forms (\`1.5e10\`, \`2E-3\`, \`1e+10\`), negative decimals (\`-2.5\`, \`-0.5e-3\`), oversized integer round-trip, byte-identical container Display, and non-number barewords still becoming \`null\`. Full suite: 52 passed; clippy \`-D warnings\` clean on both crates.