### PR TITLE
fix: close strings correctly after escaped backslashes

### DIFF
--- a/crates/partial-json-fixer/src/lib.rs
+++ b/crates/partial-json-fixer/src/lib.rs
@@ -341,7 +341,14 @@ impl<'a> JsonParser<'a> {
     fn token_as_unit(&self, token: &JsonToken) -> JsonUnit<'a> {
         let source = self.tokenizer.span_source(token);
         if source.starts_with("\"") {
-            return JsonUnit::String(source.trim_matches('"'));
+            // Strip exactly one quote from each end: the closing quote may
+            // itself be preceded by escapes (e.g. content ending in `\"`),
+            // and trim_matches would eat those content characters too.
+            let stripped = source
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .unwrap_or(source);
+            return JsonUnit::String(stripped);
         }
         if source == "true" {
             return JsonUnit::True;
@@ -647,17 +654,16 @@ impl<'a> JsonTokenizer<'a> {
 
         if c == '"' {
             // i need to consume the whole string
-            let mut previous_char = None;
+            let mut in_escape = false;
             let mut string_end_index = i + c.len_utf8();
             for (i, str_char) in self.char_indices.by_ref() {
                 string_end_index = i + str_char.len_utf8();
-                if str_char == '"' {
-                    if let Some('\\') = previous_char {
-                    } else {
-                        break;
-                    }
+                if str_char == '"' && !in_escape {
+                    break;
                 }
-                previous_char = Some(str_char);
+                // A backslash escapes only the next character: after it is
+                // consumed, the state resets so a later quote closes the string.
+                in_escape = !in_escape && str_char == '\\';
             }
             return Some(JsonToken {
                 kind: JsonTokenKind::String,

--- a/crates/partial-json-fixer/tests/tests.rs
+++ b/crates/partial-json-fixer/tests/tests.rs
@@ -351,3 +351,56 @@ mod always_parseable {
     }
 }
 
+mod escaped_backslash {
+    // https://github.com/maheshbansod/partial-json-fixer/issues/5
+    use partial_json_fixer::fix_json_parse;
+
+    fn object_member_text(input: &str) -> String {
+        object(input).values[0].1.to_string()
+    }
+
+    fn object(input: &str) -> partial_json_fixer::JsonObject<'_> {
+        match fix_json_parse(input).unwrap() {
+            partial_json_fixer::JsonValue::Object(obj) => obj,
+            other => panic!("expected an object for {input:?}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn closing_quote_after_escaped_backslash_closes_string() {
+        assert_eq!(object_member_text(r#"{"path": "C:\\"}"#), "\"C:\\\\\"");
+    }
+
+    #[test]
+    fn second_member_survives_escaped_backslash() {
+        let value = fix_json_parse(r#"{"a": "x\\", "b": 1}"#).unwrap();
+        assert_eq!(value.to_string(), r#"{"a": "x\\", "b": 1}"#);
+    }
+
+    #[test]
+    fn regular_escaped_quotes_still_work() {
+        assert_eq!(
+            object_member_text(r#"{"s": "a\"b"}"#),
+            "\"a\\\"b\"",
+            "value text should be a\"b"
+        );
+    }
+
+    #[test]
+    fn odd_backslash_count_before_quote_escapes_it() {
+        // `x\\\""` = escaped backslash + escaped quote + closing quote, so the
+        // string stays open through the escaped quote and both members parse.
+        let obj = object(r#"{"s": "x\\\"", "b": 1}"#);
+        assert_eq!(obj.values.len(), 2);
+        assert_eq!(obj.values[0].1.to_string(), "\"x\\\\\\\"\"");
+    }
+
+    #[test]
+    fn even_backslash_count_before_quote_closes_string() {
+        for input in [r#"{"s": "x\\\\", "b": 1}"#, r#"{"s": "x\\\\\\", "b": 1}"#] {
+            let obj = object(input);
+            assert_eq!(obj.values.len(), 2, "input {input:?}");
+        }
+    }
+}
+


### PR DESCRIPTION
Closes #5

## Problem
The tokenizer's string consumer detected escaped quotes by inspecting only the single previous character, so it couldn't distinguish `\"` (escaped quote) from `\\"` (escaped backslash followed by a real closing quote). On valid, complete JSON like `{"path": "C:\\"}` the closing quote and brace were swallowed into the string text; `{"a": "x\\", "b": 1}` returned `Err(ExpectedToken)`.

## Fix
- Replaced the previous-character check with an explicit `in_escape` toggle that resets after consuming the escaped character — mirroring the two-state pattern already used by `fix_json`'s bracket walker.
- `token_as_unit` now strips exactly one quote from each end of a string token instead of using `trim_matches`, which greedily ate content quotes when a string legitimately ended in an escaped quote (reachable once the tokenizer handles odd backslash runs correctly).

## Acceptance criteria
- [x] `fix_json_parse(r#"{"path": "C:\\"}"#)` succeeds; value source text is `C:\\`
- [x] `fix_json_parse(r#"{"a": "x\\", "b": 1}"#)` parses both members
- [x] Regular escaped quotes work: `{"s": "a\"b"}` → value text `a\"b`
- [x] Odd backslash count before a quote = escaped quote, string continues (`{"s": "x\\\"", "b": 1}` → both members); even count = string closes (4 and 6 backslashes tested)
- [x] All existing tests pass (49 total), clippy clean on both crates

Out of scope per the issue: escape-sequence validation and changes to `fix_json`'s bracket walker.
