### PR TITLE
docs: agent workflow notes (branch-per-issue, local test scope)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@ Incoming GitHub issues go through `/triage` before any implementation; a triaged
 issue carries an agent-brief comment, which is the contract `/implement` builds
 from. Ship changes as a branch + PR — don't commit directly to `main`.
 
+**Branch per issue, off `main`.** Start every task with
+`git switch -c <branch> main`. Never stack on or reuse an existing feature
+branch, and don't commit to one unless it's the branch you created for the
+current task — if the working tree is on another branch, switch away first.
+Stacked PRs only when the user explicitly asks.
+
 ## Layout
 
 Two independent Rust crates, no root workspace — run cargo per crate:
@@ -35,6 +41,14 @@ Two independent Rust crates, no root workspace — run cargo per crate:
 Nothing runs on plain pushes to `main`; the wheel-build matrix, PyPI
 publish (`release` job), and crates.io publish (`publish-crates` job)
 run only when a `v*` tag is pushed.
+
+**Local test runs:** only run `cargo test` and
+`cargo clippy --all-targets -- -D warnings` inside
+`crates/partial-json-fixer`. Skip the `py/partial-json-fixer` crate
+locally — its test binary links a Python framework that most dev
+machines can't resolve (dyld `Library not loaded ... Python3`, SIGABRT),
+so it fails for environment reasons before any test executes. CI covers
+both crates on every PR, so nothing is lost by skipping it.
 
 ## Releases
 


### PR DESCRIPTION
Documents two agent-workflow notes in AGENTS.md:

1. **Branch per issue, off `main`** — agents must start every task from a fresh branch off `main` and never stack on or reuse existing feature branches. Prevents the situation where new work lands on top of an unrelated unmerged branch.

2. **Local test scope** — local runs execute `cargo test` + clippy only on `crates/partial-json-fixer`; the PyO3 crate is skipped locally because its test binary fails on dyld/Python-framework resolution on dev machines before any test runs. CI already covers both crates on every PR.

No code changes.
