### PR TITLE
perf: cut allocations in Display impls and fix_json output

### DIFF
--- a/crates/partial-json-fixer/src/lib.rs
+++ b/crates/partial-json-fixer/src/lib.rs
@@ -126,7 +126,11 @@ pub fn fix_json(partial_json: &str) -> String {
         &mut wrappers,
     );
 
-    let mut final_json = partial_json[0..end_index].to_string();
+    // The repaired output is the prefix plus at most 6 bytes per unclosed
+    // wrapper (": null" being the longest closure), so a single exact
+    // allocation suffices.
+    let mut final_json = String::with_capacity(end_index + wrappers.len() * 6);
+    final_json.push_str(&partial_json[..end_index]);
     while let Some(wrapper) = wrappers.pop() {
         match wrapper {
             Wrapper::Brace => {
@@ -313,20 +317,19 @@ impl<'a> JsonParser<'a> {
     }
 
     fn parse(mut self) -> JResult<JsonValue<'a>> {
-        let (_errors, value) = self.parse_value()?;
-        Ok(value)
+        self.parse_value()
     }
 
-    fn parse_value(&mut self) -> JResult<(Vec<JsonError>, JsonValue<'a>)> {
+    fn parse_value(&mut self) -> JResult<JsonValue<'a>> {
         let token = self.tokenizer.next().ok_or(JsonError::UnexpectedEnd)?;
 
         match token.kind {
             JsonTokenKind::Null | JsonTokenKind::String | JsonTokenKind::Number => {
-                Ok((vec![], JsonValue::Unit(self.token_as_unit(&token))))
+                Ok(JsonValue::Unit(self.token_as_unit(&token)))
             }
-            JsonTokenKind::OpeningBrace => Ok((vec![], JsonValue::Object(self.parse_object()?))),
+            JsonTokenKind::OpeningBrace => Ok(JsonValue::Object(self.parse_object()?)),
             JsonTokenKind::OpeningSquareBracket => {
-                Ok((vec![], JsonValue::Array(self.parse_array()?)))
+                Ok(JsonValue::Array(self.parse_array()?))
             }
             JsonTokenKind::Comma
             | JsonTokenKind::Colon
@@ -381,7 +384,7 @@ impl<'a> JsonParser<'a> {
             if self.tokenizer.is_next_closing_square_bracket() || self.tokenizer.is_on_last() {
                 break;
             }
-            if let Ok((_errors, value)) = self.parse_value() {
+            if let Ok(value) = self.parse_value() {
                 members.push(value);
 
                 match self.tokenizer.next() {
@@ -425,8 +428,7 @@ impl<'a> JsonParser<'a> {
                 values.push((key, JsonValue::Null));
                 break;
             }
-            let (_errors, value) = value.unwrap();
-            values.push((key, value));
+            values.push((key, value.unwrap()));
 
             match self.tokenizer.next() {
                 Some(token) if matches!(token.kind, JsonTokenKind::ClosingBrace) => {
@@ -509,15 +511,14 @@ pub struct JsonArray<'a> {
 
 impl<'a> Display for JsonArray<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.members
-                .iter()
-                .map(|m| m.to_string())
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
+        f.write_str("[")?;
+        for (i, member) in self.members.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{member}")?;
+        }
+        f.write_str("]")
     }
 }
 
@@ -527,15 +528,14 @@ pub struct JsonObject<'a> {
 }
 impl<'a> Display for JsonObject<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.values
-                .iter()
-                .map(|(key, value)| format!("{}: {}", key, value))
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
+        f.write_str("{")?;
+        for (i, (key, value)) in self.values.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{key}: {value}")?;
+        }
+        f.write_str("}")
     }
 }
 


### PR DESCRIPTION
## What

Three allocation reductions in \`src/lib.rs\`, measured with the benchmarks from #14:

1. **\`Display\` for \`JsonArray\` / \`JsonObject\`**: previously rendered each member into a \`String\`, collected into a \`Vec<String>\`, then \`.join()\`ed. Now members are written directly into the formatter with separators.
2. **\`fix_json\` output string**: pre-reserves exact capacity (input prefix + at most 6 bytes per unclosed wrapper — \`: null\` being the longest closure) instead of \`to_string()\` + growth, so the output is built in a single allocation. (First attempt of this forgot to copy the prefix in — caught immediately by the existing test suite.)
3. **\`parse_value\`** no longer returns a never-populated \`Vec<JsonError>\`. Allocation-neutral in hindsight (\`vec![]\` never heap-allocates) but the signature no longer implies error accumulation that doesn't exist.

## Measured impact

Allocation counts per call (\`cargo bench --bench allocations\`):

| Path | Before | After |
|---|---|---|
| \`display/nested-objects\` | 5105 allocs / 189 KB | **13 allocs / 32 KB** |
| \`display/flat-numbers-1k\` | 1005 | **11** |
| \`display/escape-heavy\` | 855 | **11** |
| \`fix_json\` partial prefixes | 3 allocs | **2** |

Criterion A/B (identical settings on both trees):

- \`display/*\`: **−31% to −60%** wall time
- \`fix_json/*\`: −3% to −27%, no regressions
- \`fix_json_parse/*\`: flat within noise, as expected

Remaining known allocation in \`fix_json\` is the \`Vec<Wrapper>\` stack growth — a candidate for a hand-rolled inline stack if it ever matters.

57 tests pass; clippy clean.